### PR TITLE
Logger: Implement FunctionOrigin option, to substitute logger name for function's

### DIFF
--- a/source/dtext/log/Appender.d
+++ b/source/dtext/log/Appender.d
@@ -262,7 +262,7 @@ unittest
     LogEvent event = {
         level: ILogger.Level.Warn,
         name: "Barney",
-        host: new HierarchyT!(Logger)("test"),
+        host: new Hierarchy("test"),
 // https://github.com/dlang/druntime/pull/3752
 //        time: LogEvent.startTime + 420.msecs,
         time: LogEvent.startTime,

--- a/source/dtext/log/Event.d
+++ b/source/dtext/log/Event.d
@@ -43,7 +43,7 @@ public struct LogEvent
     public ILogger.Level   level;
 
     /// Name of the logger emitting this event
-    public const(char)[]   name;
+    public string          name;
 
     /// Host of the Logger emitting this event
     public ILogger.Context host;

--- a/source/dtext/log/Hierarchy.d
+++ b/source/dtext/log/Hierarchy.d
@@ -290,6 +290,27 @@ package class Hierarchy : Logger.Context
 
     /***************************************************************************
 
+         Propagates the `Level` to all child loggers.
+
+         Params:
+            parent = Name of the parent logger
+            level = New `Level` value to apply
+
+    ***************************************************************************/
+
+    package void propagateLevel (string parent, Logger.Level value)
+    {
+        foreach (log; this)
+        {
+            if (log.isChildOf(parent))
+            {
+                log.level_ = value;
+            }
+        }
+    }
+
+    /***************************************************************************
+
          Propagates the property to all child loggers.
 
          Params:

--- a/source/dtext/log/Hierarchy.d
+++ b/source/dtext/log/Hierarchy.d
@@ -24,17 +24,17 @@
 module dtext.log.Hierarchy;
 
 import std.exception: assumeUnique;
-import dtext.log.ILogger;
+import dtext.log.Logger;
 
 
 /// Ditto
-package class HierarchyT (LoggerT) : ILogger.Context
+package class Hierarchy : Logger.Context
 {
-    private LoggerT             root_;
+    private Logger              root_;
     private string              label_,
                                 address_;
-    private ILogger.Context     context_;
-    private LoggerT[string]     loggers;
+    private Logger.Context      context_;
+    private Logger[string]      loggers;
 
 
     /***************************************************************************
@@ -49,7 +49,7 @@ package class HierarchyT (LoggerT) : ILogger.Context
         this.address_ = "network";
 
         // insert a root node; the root has an empty name
-        this.root_ = new LoggerT(this, "");
+        this.root_ = new Logger(this, "");
         this.context_ = this;
     }
 
@@ -82,7 +82,7 @@ package class HierarchyT (LoggerT) : ILogger.Context
 
     ***************************************************************************/
 
-    final bool enabled (ILogger.Level level, ILogger.Level test)
+    final bool enabled (Logger.Level level, Logger.Level test)
     {
         return test >= level;
     }
@@ -118,7 +118,7 @@ package class HierarchyT (LoggerT) : ILogger.Context
 
     ***************************************************************************/
 
-    final ILogger.Context context ()
+    final Logger.Context context ()
     {
         return this.context_;
     }
@@ -133,7 +133,7 @@ package class HierarchyT (LoggerT) : ILogger.Context
 
     ***************************************************************************/
 
-    final void context (ILogger.Context context)
+    final void context (Logger.Context context)
     {
         this.context_ = context;
     }
@@ -144,28 +144,28 @@ package class HierarchyT (LoggerT) : ILogger.Context
 
     ***************************************************************************/
 
-    final LoggerT root ()
+    final Logger root ()
     {
         return this.root_;
     }
 
     /***************************************************************************
 
-        Return the instance of a LoggerT with the provided label.
+        Return the instance of a Logger with the provided label.
         If the instance does not exist, it is created at this time.
 
         Note that an empty label is considered illegal, and will be ignored.
 
     ***************************************************************************/
 
-    final LoggerT lookup (in char[] label)
+    final Logger lookup (in char[] label)
     {
         if (!label.length)
             return null;
 
         return this.inject(
             label,
-            (in char[] name) { return new LoggerT(this, name.idup); }
+            (in char[] name) { return new Logger(this, name.idup); }
             );
     }
 
@@ -175,7 +175,7 @@ package class HierarchyT (LoggerT) : ILogger.Context
 
     ***************************************************************************/
 
-    final int opApply (scope int delegate(ref LoggerT) dg)
+    final int opApply (scope int delegate(ref Logger) dg)
     {
         int ret;
 
@@ -187,13 +187,13 @@ package class HierarchyT (LoggerT) : ILogger.Context
 
     /***************************************************************************
 
-        Return the instance of a LoggerT with the provided label.
+        Return the instance of a Logger with the provided label.
         If the instance does not exist, it is created at this time.
 
     ***************************************************************************/
 
-    private LoggerT inject (in char[] label,
-                            scope LoggerT delegate(in char[] name) dg)
+    private Logger inject (in char[] label,
+                           scope Logger delegate(in char[] name) dg)
     {
         // try not to allocate unless you really need to
         char[255] stack_buffer;
@@ -244,10 +244,10 @@ package class HierarchyT (LoggerT) : ILogger.Context
 
     ***************************************************************************/
 
-    private void insert (LoggerT l)
+    private void insert (Logger l)
     {
-        LoggerT prev,
-                curr = this.root;
+        Logger prev,
+               curr = this.root;
 
         while (curr)
         {
@@ -282,7 +282,7 @@ package class HierarchyT (LoggerT) : ILogger.Context
 
     ***************************************************************************/
 
-    private void update (LoggerT changed, bool force = false)
+    private void update (Logger changed, bool force = false)
     {
         foreach (logger; this)
             this.propagate(logger, changed, force);
@@ -320,7 +320,7 @@ package class HierarchyT (LoggerT) : ILogger.Context
 
     ***************************************************************************/
 
-    private void propagate (LoggerT logger, LoggerT changed, bool force = false)
+    private void propagate (Logger logger, Logger changed, bool force = false)
     {
         // is the changed instance a better match for our parent?
         if (logger.isCloserAncestor(changed))

--- a/source/dtext/log/Hierarchy.d
+++ b/source/dtext/log/Hierarchy.d
@@ -314,21 +314,22 @@ package class Hierarchy : Logger.Context
          Propagates the property to all child loggers.
 
          Params:
-            property = property to set
-            T = type of the property
-            parent_name = name of the parent logger
-            value = value to set
+            parent = Name of the parent logger
+            option = Option to set
+            value = Value to set `option` to
 
     ***************************************************************************/
 
-    package void propagateValue (string property, T)
-        (string parent_name, T value)
+    package void propagateOption (string parent, LogOption option, bool value)
     {
         foreach (log; this)
         {
-            if (log.isChildOf (parent_name))
+            if (log.isChildOf(parent))
             {
-                mixin("log." ~ property ~ " = value;");
+                if (value)
+                    log.options_ |= option;
+                else
+                    log.options_ &= ~option;
             }
         }
     }
@@ -354,7 +355,10 @@ package class Hierarchy : Logger.Context
             if (force)
             {
                 logger.level_ = changed.level;
-                logger.collect_stats = changed.collect_stats;
+                if (changed.options_ & LogOption.CollectStats)
+                    logger.options_ |= LogOption.CollectStats;
+                else
+                    logger.options_ &= !LogOption.CollectStats;
             }
         }
     }

--- a/source/dtext/log/ILogger.d
+++ b/source/dtext/log/ILogger.d
@@ -61,9 +61,11 @@ interface ILogger
     public enum Option : uint
     {
         /// Use the `Logger` ancestors' `Appender` as well as the `Logger`'s own
-        Additive     = (1 << 0),
+        Additive       = (1 << 0),
         /// Count emitted event towards the global stats
-        CollectStats = (1 << 1),
+        CollectStats   = (1 << 1),
+        /// Use function names instead of logger name for `Event.name`
+        FunctionOrigin = (1 << 2),
     }
 
     /// Internal struct to associate a `Level` with its name
@@ -240,13 +242,14 @@ interface ILogger
             exp   = Lazily evaluated message string
                     If the `level` is not enabled for this logger, it won't
                     be evaluated.
+            func = Function from which the call originated
 
         Returns:
             `this` for easy chaining
 
     ***************************************************************************/
 
-    public ILogger append (Level level, lazy const(char)[] exp);
+    public ILogger append (Level level, lazy const(char)[] exp, string func = __FUNCTION__);
 }
 
 unittest

--- a/source/dtext/log/ILogger.d
+++ b/source/dtext/log/ILogger.d
@@ -61,7 +61,9 @@ interface ILogger
     public enum Option : uint
     {
         /// Use the `Logger` ancestors' `Appender` as well as the `Logger`'s own
-        Additive = (1 << 0),
+        Additive     = (1 << 0),
+        /// Count emitted event towards the global stats
+        CollectStats = (1 << 1),
     }
 
     /// Internal struct to associate a `Level` with its name

--- a/source/dtext/log/ILogger.d
+++ b/source/dtext/log/ILogger.d
@@ -54,7 +54,7 @@ interface ILogger
         Fatal,
         /// No message should be output
         None,
-    };
+    }
 
     /// List of options that can be set on a `Logger`
     /// Those are used as flags (bitwise-ORed together).

--- a/source/dtext/log/ILogger.d
+++ b/source/dtext/log/ILogger.d
@@ -56,6 +56,14 @@ interface ILogger
         None,
     };
 
+    /// List of options that can be set on a `Logger`
+    /// Those are used as flags (bitwise-ORed together).
+    public enum Option : uint
+    {
+        /// Use the `Logger` ancestors' `Appender` as well as the `Logger`'s own
+        Additive = (1 << 0),
+    }
+
     /// Internal struct to associate a `Level` with its name
     private struct Pair
     {

--- a/source/dtext/log/ILogger.d
+++ b/source/dtext/log/ILogger.d
@@ -206,29 +206,30 @@ interface ILogger
 
     /***************************************************************************
 
-        Returns:
-            `true` if the logger is additive.
-            Additive loggers walk through ancestors looking for more appenders
+        Test whether an option is enabled or not
+
+        Loggers support different options, listed in `LogOption`.
+        This function returns whether a certain option is enabled or not.
 
     ***************************************************************************/
 
-    public bool additive ();
+    public bool getOption (Option option) const scope @safe pure nothrow @nogc;
 
     /***************************************************************************
 
-        Set the additive status of this logger
-
-        Additive loggers walk through ancestors looking for more appenders
+        Enable or disable a certain option
 
         Params:
-            enabled = Whereas this logger is additive.
+            option = The option to enable/disable
+            enabled = If `true`, enable the option, otherwise disable it
+            propagate = Whether the option should be propagated to child loggers
 
         Returns:
-            `this` for easy chaining
+            `true` if the option was previously enabled, `false` otherwise.
 
     ***************************************************************************/
 
-    public ILogger additive (bool enabled);
+    public bool setOption (Option option, bool enabled, bool propagate = false);
 
     /***************************************************************************
 

--- a/source/dtext/log/Logger.d
+++ b/source/dtext/log/Logger.d
@@ -190,7 +190,7 @@ public struct Log
     }
 
     /// Stores all the existing `Logger` in a hierarchical manner
-    private static HierarchyT!(Logger) hierarchy_;
+    private static Hierarchy hierarchy_;
 
     /// Logger stats
     private static Stats logger_stats;
@@ -272,18 +272,18 @@ public struct Log
         Return (and potentially initialize) the hierarchy singleton
 
         Logger themselves have little knowledge about their hierarchy.
-        Everything is handled by a `HierarchyT!(Logger)` instance, which is
+        Everything is handled by a `Hierarchy` instance, which is
         stored as a singleton in this `struct`, and for which convenient
         functions are provided.
         This function returns said singleton, and initialize it on first call.
 
     ***************************************************************************/
 
-    public static HierarchyT!(Logger) hierarchy ()
+    public static Hierarchy hierarchy ()
     {
         if (This.hierarchy_ is null)
         {
-            This.hierarchy_ = new HierarchyT!(Logger)("ocean");
+            This.hierarchy_ = new Hierarchy("ocean");
         }
         return This.hierarchy_;
     }
@@ -407,7 +407,7 @@ public final class Logger : ILogger
     public alias Level.Fatal Fatal;     /// Ditto
 
     /// The hierarchy that host this logger (most likely Log.hierarchy).
-    private HierarchyT!(Logger) host_;
+    private Hierarchy       host_;
     /// Next logger in the list, maintained by Hierarchy
     package Logger          next;
     /// Parent of this logger (maintained by Hierarchy)
@@ -437,7 +437,7 @@ public final class Logger : ILogger
 
     ***************************************************************************/
 
-    package this (HierarchyT!(Logger) host, string name)
+    package this (Hierarchy host, string name)
     {
         this.host_ = host;
         this.level_ = Level.Trace;

--- a/source/dtext/log/Logger.d
+++ b/source/dtext/log/Logger.d
@@ -965,7 +965,7 @@ unittest
     static immutable TestStr = "Ce qui se conçoit bien s'énonce clairement - Et les mots pour le dire arrivent aisément";
     scope appender = new Buffer();
     char[32] log_buffer;
-    Logger log = new Logger(Log.hierarchy(), "dummy");
+    Logger log = new Logger(Log.hierarchy(), "dummy.");
     log.setOption(LogOption.Additive, false);
     log.add(appender).buffer(log_buffer);
     log.info("{}", TestStr);
@@ -984,7 +984,13 @@ unittest
 {
     static class StaticBuffer : Appender
     {
-        public struct Event { Logger.Level level; const(char)[] message; char[128] buffer; }
+        public struct Event
+        {
+            Logger.Level level;
+            const(char)[] name;
+            const(char)[] message;
+            char[128] buffer;
+        }
 
         private Event[6] buffers;
         private size_t index;
@@ -996,12 +1002,13 @@ unittest
             assert(this.index < this.buffers.length);
             auto str = snformat(this.buffers[this.index].buffer, "{}", e.msg);
             this.buffers[this.index].message = str;
+            this.buffers[this.index].name = e.name;
             this.buffers[this.index++].level = e.level;
         }
     }
 
     scope appender = new StaticBuffer;
-    Logger log = new Logger(Log.hierarchy(), "dummy");
+    Logger log = new Logger(Log.hierarchy(), "dummy.");
     log.setOption(LogOption.Additive, false);
     log.add(appender);
 
@@ -1036,4 +1043,8 @@ unittest
     assert(appender.buffers[4].message ==
            "This is some arg fmt - 42 - object.Object - 1337.00");
     assert(appender.buffers[5].message == "Just some more allocation tests");
+
+    // Test logger names
+    foreach (idx; 0 .. 6)
+        assert(appender.buffers[idx].name == "dummy");
 }

--- a/source/dtext/log/Logger.d
+++ b/source/dtext/log/Logger.d
@@ -654,7 +654,7 @@ public final class Logger : ILogger
 
         if (propagate)
         {
-            this.host_.propagateValue!("level_")(this.name_, level);
+            this.host_.propagateLevel(this.name_, level);
         }
 
         return this;

--- a/source/dtext/log/Logger.d
+++ b/source/dtext/log/Logger.d
@@ -62,12 +62,7 @@ version (unittest)
     import dtext.Test;
 }
 
-/*******************************************************************************
-
-    These represent the standard LOG4J event levels.
-
-*******************************************************************************/
-
+/// Convenience alias to available log level, see `ILogger.Level`
 public alias ILogger.Level Level;
 
 

--- a/source/dtext/log/layout/LayoutSimple.d
+++ b/source/dtext/log/layout/LayoutSimple.d
@@ -27,32 +27,36 @@ version (unittest)
 
 /*******************************************************************************
 
-   A simple layout, prefixing each message with the log level and
-   the name of the logger.
+    A simple layout, prefixing each message with the log level and
+    the name of the logger.
 
-   Example:
-   ------
-   import dtext.log.layout.LayoutSimple;
-   import dtext.log.Logger;
-   import dtext.log.AppendConsole;
+    Example:
+    ------
+    module foobar;
 
+    import dtext.log.layout.LayoutSimple;
+    import dtext.log.Logger;
+    import dtext.log.AppendConsole;
 
-   Log.root.clear;
-   Log.root.add(new AppendConsole(new LayoutSimple));
+    void main ()
+    {
+        Log.root.clear;
+        Log.root.add(new AppendConsole(new LayoutSimple));
 
-   auto logger = Log.lookup("Example");
+        auto logger = Log.lookup("Example");
 
-   logger.trace("Trace example");
-   logger.error("Error example");
-   logger.fatal("Fatal example");
-   -----
+        logger.trace("Trace example");
+        logger.error("Error example");
+        logger.fatal("Fatal example");
+    }
+    -----
 
-   Produced output:
-   -----
-   Trace [Example] - Trace example
-   Error [Example] - Error example
-   Fatal [Example] - Fatal example
-   ----
+    Produced output:
+    -----
+    Trace [Example] - Trace example
+    Error [Example] - Error example
+    Fatal [Example] - Fatal example
+    ----
 
 *******************************************************************************/
 

--- a/source/dtext/log/layout/LayoutSimple.d
+++ b/source/dtext/log/layout/LayoutSimple.d
@@ -76,8 +76,7 @@ public class LayoutSimple : Appender.Layout
     }
 }
 
-version(LDC) {}
-else unittest
+unittest
 {
     auto result = new char[](2048);
     result.length = 0;


### PR DESCRIPTION
```
This follows the well-established practice of having a `Logger` per module,
or more granular. Having a Logger per function would not be practical,
and expensive, and adding a field to `Event` would lead to a duplication
of `Layout` (as e.g. `LayoutDate` would need to account for it).

The most practical way for the user seems to be to provide the ability
to substitute the Logger name for the name of the function the calls
originate from, which this implements.
```

Comes with a bunch of fixes / refactoring as I tried a few approaches before settling on this one.
Will test in Agora.