### PR TITLE
Logger: Propagate all changed options, not just CollectStats

### DIFF
--- a/source/dtext/log/Hierarchy.d
+++ b/source/dtext/log/Hierarchy.d
@@ -355,10 +355,7 @@ package class Hierarchy : Logger.Context
             if (force)
             {
                 logger.level_ = changed.level;
-                if (changed.options_ & LogOption.CollectStats)
-                    logger.options_ |= LogOption.CollectStats;
-                else
-                    logger.options_ &= !LogOption.CollectStats;
+                logger.options_ = changed.options_;
             }
         }
     }


### PR DESCRIPTION
When a Logger is inserted into the Hierarchy, propagate is called.
Before this commit, only CollectStats was propagated,
which means setting FunctionOrigin on the root logger then
adding other loggers would not work as expected.
Likewise, setting the root logger as additive most likely
means child loggers should be additive too,
hence propagating all options make more sense.