### PR TITLE
Fix deprecation warning by using preview integer promotion

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,7 +1,7 @@
 {
     "name": "dtext",
     "description": "A library providing a formatter and logger for D",
-    "dflags": [ "-preview=in" ],
+    "dflags": [ "-preview=in", "-preview=intpromote" ],
 
     "configurations": [
         {


### PR DESCRIPTION
Integer promotion deprecated for negative int which was used in tango format statement.
Warning during Agora build was 
```
source/dtext/format/Integer_tango.d(111,32): Deprecation: integral promotion not done for `-i_`, use '-preview=intpromote' switch or `-cast(int)(i_)`
```